### PR TITLE
Implement a per-client retry budget.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,10 @@ succeed or the action is cancelled, for example due to a timeout. Retrying
 operations is a common strategy to deal with temporary failures in distributed
 systems, for example when using Remote Procedure Calls (RPCs).
 
-Support for the `context` is the main feature setting this `retry` package
-apart.
+### context package
+
+Support for the `context` package is one of the main features setting this
+`retry` package apart.
 Contexts are Go's idiomatic way to make a call with a deadline and to cancel
 ongoing calls early. Refer to [Go Concurrency Patterns:
 Context](https://blog.golang.org/context) for more information on contexts.
@@ -21,6 +23,23 @@ callback so the callback can implement the concurrency pattern, too.
 [The documentation](https://godoc.org/github.com/octo/retry) has examples
 demonstrating how the `retry` and `context` packages interact.
 
+### SRE best practices
+
+Features and defaults in this package are heavily influenced by the [SRE
+book](https://landing.google.com/sre/book.html), particularly the chapters
+[Handling
+Overload](https://landing.google.com/sre/book/chapters/handling-overload.html)
+and [Addressing Cascading
+Failures](https://landing.google.com/sre/book/chapters/addressing-cascading-failures.html).
+By default this package uses
+[Jitter](https://godoc.org/github.com/octo/retry#Jitter) to evenly distribute
+retries over the retry period and limits the number of
+[Attempts](https://godoc.org/github.com/octo/retry#Attempts) per request. A
+[retry budget](https://godoc.org/github.com/octo/retry#Budget) optionally limits
+the number of retries sent to a backend to prevent overload.
+
+### Permanent failures
+
 The ability to abort retries is another differentiator.
 The `retry` package allows to cancel retries on permanent errors, for example
 HTTP 4xx errors and invalid network addresses.
@@ -29,6 +48,8 @@ The retried code can signal a permanent failure by wrapping the error with
 error implementing the [`Error`](https://godoc.org/github.com/octo/retry#Error)
 interface. The `Error` interface is a subset of `net.Error`, i.e. permanent
 failures reported by the `net` package are automatically detected.
+
+### HTTP transport
 
 A [`Transport`](https://godoc.org/github.com/octo/retry#Transport) type
 implements all the logic required for retrying HTTP requests. The `Transport`

--- a/budget.go
+++ b/budget.go
@@ -1,0 +1,61 @@
+package retry
+
+import (
+	"math"
+	"sync"
+	"time"
+)
+
+// Budget implements a client-side retry budget, i.e. a rate limit for retries.
+// Rate-limiting the amount of retries sent to a service helps to mitigate cascading failures.
+//
+// To add a retry budget for a specific service or backend, declare a Budget
+// variable that is shared by all Do() calls. See the example for a demonstration.
+//
+// Budget implements a token bucket algorithm.
+//
+// Implements the Option interface.
+type Budget struct {
+	// Rate is the rate at which tokens are added to the bucket, i.e. the
+	// sustained retry rate in retries per second.
+	// Must be greater than zero.
+	Rate float64
+	// Burst is the maximum number of tokens in the bucket, i.e. the burst
+	// size with which retries are performed.
+	// Must be greater than one.
+	Burst float64
+
+	mu         sync.Mutex
+	fill       float64
+	lastUpdate time.Time
+}
+
+func (b *Budget) apply(opts *internalOptions) {
+	opts.budget = b
+}
+
+func (b *Budget) check() bool {
+	if b == nil {
+		return true
+	}
+
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	// update b.fill
+	if b.lastUpdate.IsZero() {
+		b.fill = b.Burst
+	} else {
+		s := time.Since(b.lastUpdate).Seconds()
+		b.fill = math.Min(b.fill+b.Rate*s, b.Burst)
+	}
+	b.lastUpdate = time.Now()
+
+	if b.fill < 1.0 {
+		// budget exhausted
+		return false
+	}
+
+	b.fill -= 1.0
+	return true
+}

--- a/budget.go
+++ b/budget.go
@@ -7,35 +7,46 @@ import (
 	"time"
 )
 
-// Budget implements a client-side retry budget, i.e. a rate limit for retries.
-// Rate-limiting the amount of retries sent to a service helps to mitigate cascading failures.
+// Budget implements a client-side retry budget, i.e. a limit for retries.
+// Limiting the amount of retries sent to a service helps to mitigate cascading failures.
 //
 // To add a retry budget for a specific service or backend, declare a Budget
 // variable that is shared by all Do() calls. See the example for a demonstration.
 //
-// Budget implements a token bucket algorithm.
+// Budget calculates the rate of retries and the rate of total calls over a
+// moving one minute window. If the rate of retries exceeds Budget.Rate and the
+// ratio of retries to total calls exceeds Budget.Ratio, then retries are
+// dropped. Initial attempts are never dropped.
 //
 // Implements the Option interface.
 type Budget struct {
-	// Rate is the rate at which tokens are added to the bucket, i.e. the
-	// sustained retry rate in retries per second.
-	// Must be greater than zero.
+	// Rate is the minimum rate of retries (in calls per second).
+	// If fewer retries are attempted than this rate, retries are never throttled.
 	Rate float64
-	// Burst is the maximum number of tokens in the bucket, i.e. the burst
-	// size with which retries are performed.
-	// Must be greater than one.
-	Burst float64
 
-	mu         sync.Mutex
-	fill       float64
-	lastUpdate time.Time
+	// Ratio is the maximum ratio of retries to total calls.
+	// It is a number in the [0.0, 1.0] range.
+	Ratio float64
+
+	mu           sync.Mutex
+	retriedCalls *movingRate
+	totalCalls   *movingRate
 }
 
 func (b *Budget) apply(opts *internalOptions) {
+	b.retriedCalls = &movingRate{
+		BucketLength: time.Second,
+		BucketNum:    60,
+	}
+	b.totalCalls = &movingRate{
+		BucketLength: time.Second,
+		BucketNum:    60,
+	}
+
 	opts.budget = b
 }
 
-func (b *Budget) check() bool {
+func (b *Budget) check(isRetry bool) bool {
 	if b == nil {
 		return true
 	}
@@ -43,21 +54,22 @@ func (b *Budget) check() bool {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
-	// update b.fill
-	if b.lastUpdate.IsZero() {
-		b.fill = b.Burst
-	} else {
-		s := time.Since(b.lastUpdate).Seconds()
-		b.fill = math.Min(b.fill+b.Rate*s, b.Burst)
-	}
-	b.lastUpdate = time.Now()
+	t := time.Now()
 
-	if b.fill < 1.0 {
-		// budget exhausted
+	if !isRetry {
+		b.totalCalls.Add(t, 1)
+		return true
+	}
+
+	totalRate := b.totalCalls.Rate(t)
+	retriedRate := b.retriedCalls.Rate(t)
+	if totalRate > b.Rate &&
+		retriedRate/totalRate > b.Ratio {
 		return false
 	}
 
-	b.fill -= 1.0
+	b.totalCalls.Add(t, 1)
+	b.retriedCalls.Add(t, 1)
 	return true
 }
 

--- a/budget.go
+++ b/budget.go
@@ -59,3 +59,116 @@ func (b *Budget) check() bool {
 	b.fill -= 1.0
 	return true
 }
+
+type movingRate struct {
+	historyCounts    []int
+	historyTimestamp int64
+	historySize      int
+
+	stagingCount     int
+	stagingTimestamp int64
+}
+
+func newMovingRate(size int) *movingRate {
+	return &movingRate{
+		historySize: size,
+	}
+}
+
+// commitToHistory appends the provided counts to historyCounts.
+// If the number of elements in historyCounts exceeds historySize, the oldest entries are purged.
+// historyTimestamp is advanced by len(count).
+func (mr *movingRate) commitToHistory(count ...int) {
+	mr.historyCounts = append(mr.historyCounts, count...)
+	if len(mr.historyCounts) > mr.historySize {
+		idx := len(mr.historyCounts) - mr.historySize
+		mr.historyCounts = mr.historyCounts[idx:]
+	}
+
+	mr.historyTimestamp += int64(len(count))
+}
+
+// clearHistory clears the history and updates historyTimestamp.
+func (mr *movingRate) clearHistory(ts int64) {
+	mr.historyCounts = []int{}
+	mr.historyTimestamp = ts
+}
+
+// forwardHistory ensures that the newest element in historyCounts represents the timestamp ts.
+// If ts is much larger than historyTimestamp (i.e. all elements would be
+// zero), then historyCounts is reset to an empty slice.
+func (mr *movingRate) forwardHistory(ts int64) {
+	if ts <= mr.historyTimestamp {
+		return
+	}
+
+	if mr.historyTimestamp+int64(mr.historySize) <= ts {
+		mr.clearHistory(ts)
+		return
+	}
+
+	zero := make([]int, ts-mr.historyTimestamp)
+	mr.commitToHistory(zero...)
+}
+
+// persistStaging appends stagingCount to historyCounts.
+func (mr *movingRate) persistStaging() {
+	if mr.stagingTimestamp == 0 {
+		return
+	}
+
+	mr.forwardHistory(mr.stagingTimestamp - 1)
+	mr.commitToHistory(mr.stagingCount)
+
+	mr.stagingCount = 0
+	mr.stagingTimestamp++
+}
+
+// forwardStaging updates all internal state so that stagingTimestamp == ts and
+// historyTimestamp == ts-1.
+func (mr *movingRate) forwardStaging(ts int64) {
+	if ts <= mr.stagingTimestamp {
+		return
+	}
+
+	mr.persistStaging()
+	mr.forwardHistory(ts - 1)
+	mr.stagingTimestamp = ts
+}
+
+func (mr *movingRate) sum() float64 {
+	var s float64
+	for _, c := range mr.historyCounts {
+		s += float64(c)
+	}
+
+	return s
+}
+
+func (mr *movingRate) num() float64 {
+	return float64(len(mr.historyCounts))
+}
+
+func (mr *movingRate) Rate(t time.Time) float64 {
+	if t.Unix() < mr.stagingTimestamp {
+		return math.NaN()
+	}
+
+	mr.forwardStaging(t.Unix())
+
+	if len(mr.historyCounts) == 0 {
+		return 0.0
+	}
+
+	return mr.sum() / mr.num()
+}
+
+func (mr *movingRate) Add(t time.Time, n int) {
+	if t.Unix() < mr.stagingTimestamp {
+		return
+	}
+
+	mr.forwardStaging(t.Unix())
+
+	mr.stagingCount += n
+}

--- a/budget.go
+++ b/budget.go
@@ -34,15 +34,6 @@ type Budget struct {
 }
 
 func (b *Budget) apply(opts *internalOptions) {
-	b.retriedCalls = &movingRate{
-		BucketLength: time.Second,
-		BucketNum:    60,
-	}
-	b.totalCalls = &movingRate{
-		BucketLength: time.Second,
-		BucketNum:    60,
-	}
-
 	opts.budget = b
 }
 
@@ -53,6 +44,19 @@ func (b *Budget) check(isRetry bool) bool {
 
 	b.mu.Lock()
 	defer b.mu.Unlock()
+
+	if b.retriedCalls == nil {
+		b.retriedCalls = &movingRate{
+			BucketLength: time.Second,
+			BucketNum:    60,
+		}
+	}
+	if b.totalCalls == nil {
+		b.totalCalls = &movingRate{
+			BucketLength: time.Second,
+			BucketNum:    60,
+		}
+	}
 
 	t := time.Now()
 

--- a/budget.go
+++ b/budget.go
@@ -185,11 +185,5 @@ func (mr *movingRate) Rate(t time.Time) float64 {
 	}
 
 	mr.forward(t)
-
-	cnt := mr.count()
-	if cnt == 0.0 {
-		return 0.0
-	}
-
-	return cnt / mr.second()
+	return mr.count() / mr.second()
 }

--- a/budget_test.go
+++ b/budget_test.go
@@ -15,7 +15,7 @@ func ExampleBudget() {
 	// fooRetryBudget is a global variable holding the state of foo's retry budget.
 	var fooRetryBudget = Budget{
 		Rate:  1.0,
-		Burst: 10,
+		Ratio: 0.1,
 	}
 
 	// failingRPC is a fake RPC call simulating a permanent backend
@@ -43,8 +43,8 @@ func TestBudget(t *testing.T) {
 	ctx := context.Background()
 
 	b := &Budget{
-		Rate:  60,
-		Burst: 10,
+		Rate:  10,
+		Ratio: 0.1,
 	}
 
 	rpcCalls := 0
@@ -73,8 +73,10 @@ func TestBudget(t *testing.T) {
 	}
 
 	wg.Wait()
-	if rpcCalls != 110 {
-		t.Errorf("rpcCalls = %d, want 110", rpcCalls)
+
+	// 100 tries, 10% retries + some slack -> 115
+	if got, want := rpcCalls, 115; got > want {
+		t.Errorf("rpcCalls = %d, want <=%d", got, want)
 	}
 }
 

--- a/budget_test.go
+++ b/budget_test.go
@@ -95,30 +95,38 @@ func TestMovingRate(t *testing.T) {
 			wantSecond: 1.2,
 		},
 		{
-			calls:      []int{5, 3, 1},
-			wantCount:  9,
+			calls:      []int{5, 5, 1},
+			wantCount:  11,
 			wantSecond: 2.2,
 		},
 		{
-			calls:      []int{2, 2, 2, 2, 2, 2, 2, 2, 2, 2},
-			wantCount:  20,
+			calls:      []int{5, 5, 5, 5, 5, 5, 5, 5, 5, 1},
+			wantCount:  9*5 + 1,
 			wantSecond: 9.2,
 		},
 		{
 			calls: []int{
-				1000000, // old
+				5, // partial value
+				5, 5, 5, 5, 5, 5, 5, 5, 5, 1},
+			wantCount:  5*.8 + 9*5 + 1,
+			wantSecond: 10,
+		},
+		{
+			calls: []int{
+				1000000, // partial value
 				2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
 			},
-			wantCount:  20,
-			wantSecond: 9.2,
+			wantCount:  1000000*.8 + 20,
+			wantSecond: 10.0,
 		},
 		{
 			calls: []int{
-				2, 2, 2, 2, 2, // old
-				1, 1, 1, 1, 0, 0, 0, 0, 0, 1, // history
+				2, 2, 2, 2, // old
+				5, // partial
+				1, 1, 1, 1, 0, 0, 0, 0, 0, 1,
 			},
-			wantCount:  5,
-			wantSecond: 9.2,
+			wantCount:  5*.8 + 5,
+			wantSecond: 10.0,
 		},
 	}
 

--- a/budget_test.go
+++ b/budget_test.go
@@ -1,0 +1,79 @@
+package retry
+
+import (
+	"context"
+	"errors"
+	"log"
+	"sync"
+	"testing"
+	"time"
+)
+
+func ExampleBudget() {
+	ctx := context.Background()
+
+	// fooRetryBudget is a global variable holding the state of foo's retry budget.
+	var fooRetryBudget = Budget{
+		Rate:  1.0,
+		Burst: 10,
+	}
+
+	// failingRPC is a fake RPC call simulating a permanent backend
+	// failure.
+	failingRPC := func(_ context.Context) error {
+		return errors.New("permanent failure")
+	}
+
+	// Simulate 100 concurrent requests. Each request is tried initially,
+	// but only 10 requests are retried, i.e. there will be 110 calls of
+	// failingRPC in total.
+	for i := 0; i < 100; i++ {
+		go func() {
+			// Pass a pointer to fooRetryBudget to all Do() calls,
+			// i.e. all Do() calls receive a the same Budget{}.
+			// This allows state to be shared between Do() calls.
+			if err := Do(ctx, failingRPC, &fooRetryBudget); err != nil {
+				log.Println(err)
+			}
+		}()
+	}
+}
+
+func TestBudget(t *testing.T) {
+	ctx := context.Background()
+
+	b := &Budget{
+		Rate:  60,
+		Burst: 10,
+	}
+
+	rpcCalls := 0
+	rpcCallsLock := &sync.Mutex{}
+	failingRPC := func(_ context.Context) error {
+		rpcCallsLock.Lock()
+		defer rpcCallsLock.Unlock()
+
+		rpcCalls++
+
+		return errors.New("permanent failure")
+	}
+
+	wg := &sync.WaitGroup{}
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			Do(ctx, failingRPC, b,
+				ExpBackoff{
+					Base:   time.Millisecond,
+					Max:    8 * time.Millisecond,
+					Factor: 2.0,
+				})
+		}()
+	}
+
+	wg.Wait()
+	if rpcCalls != 110 {
+		t.Errorf("rpcCalls = %d, want 110", rpcCalls)
+	}
+}

--- a/budget_test.go
+++ b/budget_test.go
@@ -74,8 +74,8 @@ func TestBudget(t *testing.T) {
 
 	wg.Wait()
 
-	// 100 tries, 10% retries + some slack -> 115
-	if got, want := rpcCalls, 115; got > want {
+	// 100 tries, 10% retries + some slack -> 112
+	if got, want := rpcCalls, 112; got > want {
 		t.Errorf("rpcCalls = %d, want <=%d", got, want)
 	}
 }

--- a/budget_test.go
+++ b/budget_test.go
@@ -13,24 +13,24 @@ func ExampleBudget() {
 	ctx := context.Background()
 
 	// fooRetryBudget is a global variable holding the state of foo's retry budget.
+	// You should have one retry budget per backend service.
 	var fooRetryBudget = Budget{
 		Rate:  1.0,
 		Ratio: 0.1,
 	}
 
-	// failingRPC is a fake RPC call simulating a permanent backend
-	// failure.
+	// failingRPC is a fake RPC call simulating a temporary backend failure.
 	failingRPC := func(_ context.Context) error {
-		return errors.New("permanent failure")
+		return errors.New("temporary failure")
 	}
 
 	// Simulate 100 concurrent requests. Each request is tried initially,
-	// but only 10 requests are retried, i.e. there will be 110 calls of
-	// failingRPC in total.
+	// but only ~10 requests are retried, i.e. there will be approximately
+	// 110 calls of failingRPC in total.
 	for i := 0; i < 100; i++ {
 		go func() {
 			// Pass a pointer to fooRetryBudget to all Do() calls,
-			// i.e. all Do() calls receive a the same Budget{}.
+			// i.e. all Do() calls receive a pointer to the same Budget{}.
 			// This allows state to be shared between Do() calls.
 			if err := Do(ctx, failingRPC, &fooRetryBudget); err != nil {
 				log.Println(err)

--- a/budget_test.go
+++ b/budget_test.go
@@ -43,7 +43,7 @@ func TestBudget(t *testing.T) {
 	ctx := context.Background()
 
 	b := &Budget{
-		Rate:  10,
+		Rate:  1.0,
 		Ratio: 0.1,
 	}
 
@@ -55,7 +55,7 @@ func TestBudget(t *testing.T) {
 
 		rpcCalls++
 
-		return errors.New("permanent failure")
+		return errors.New("temporary failure")
 	}
 
 	wg := &sync.WaitGroup{}

--- a/retry.go
+++ b/retry.go
@@ -137,10 +137,8 @@ func do(ctx context.Context, cb func(context.Context) error, opts internalOption
 
 	var err error
 	for i := 0; Attempts(i) < opts.Attempts || opts.Attempts == 0; i++ {
-		if i != 0 {
-			if !opts.budget.check() {
-				return errors.New("retry budget exhausted")
-			}
+		if !opts.budget.check(i != 0) {
+			return errors.New("retry budget exhausted")
 		}
 
 		go func(ctx context.Context) {

--- a/retry.go
+++ b/retry.go
@@ -3,6 +3,7 @@ package retry
 
 import (
 	"context"
+	"errors"
 	"math"
 	"time"
 )
@@ -14,6 +15,7 @@ type backoff interface {
 type internalOptions struct {
 	Attempts
 	backoff
+	budget *Budget
 	Jitter
 	Timeout
 }
@@ -135,6 +137,12 @@ func do(ctx context.Context, cb func(context.Context) error, opts internalOption
 
 	var err error
 	for i := 0; Attempts(i) < opts.Attempts || opts.Attempts == 0; i++ {
+		if i != 0 {
+			if !opts.budget.check() {
+				return errors.New("retry budget exhausted")
+			}
+		}
+
 		go func(ctx context.Context) {
 			if opts.Timeout != 0 {
 				ch <- callWithTimeout(ctx, cb, opts.Timeout)


### PR DESCRIPTION
The retry budget is primarily specified as a ratio of total requests. A cut-off rate disables the ratio when the rate of retries is too low to pose a risk for the service.

This takes a lot of inspiration from the SRE book, especially the [Handling Overload](https://landing.google.com/sre/book/chapters/handling-overload.html#deciding-to-retry-4ksZczHj) chapter.