### PR TITLE
Implement Attempt(ctx), returning the request index.

### DIFF
--- a/http_test.go
+++ b/http_test.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"log"
 	"net/http"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -21,6 +22,12 @@ func (t *testTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 		return nil, errors.New("req.Body == nil")
 	}
 	defer req.Body.Close()
+
+	if a := Attempt(req.Context()); a != 0 {
+		if got, want := req.Header.Get("Retry-Attempt"), strconv.Itoa(a); got != want {
+			return nil, fmt.Errorf("req.Header.Get(\"Retry-Attempt\") = %q, want %q", got, want)
+		}
+	}
 
 	payload, err := ioutil.ReadAll(req.Body)
 	if err != nil {

--- a/retry.go
+++ b/retry.go
@@ -102,6 +102,25 @@ func Abort(err error) Error {
 	return permanentError{err}
 }
 
+var contextAttemptKey struct{}
+
+func withAttempt(ctx context.Context, attempt int) context.Context {
+	return context.WithValue(ctx, contextAttemptKey, attempt)
+}
+
+// Attempt returns the number of previous attempts. In other words, it returns
+// the zero-based index of the request.
+//
+// Only call this function from within a retried function.
+func Attempt(ctx context.Context) int {
+	i := ctx.Value(contextAttemptKey)
+	if i == nil {
+		return 0
+	}
+
+	return i.(int)
+}
+
 // Do repeatedly calls cb until it succeeds. After cb fails (returns a non-nil
 // error), execution is paused for an exponentially increasing time. Execution
 // can be cancelled at any time by cancelling the context.
@@ -137,6 +156,8 @@ func do(ctx context.Context, cb func(context.Context) error, opts internalOption
 
 	var err error
 	for i := 0; Attempts(i) < opts.Attempts || opts.Attempts == 0; i++ {
+		ctx := withAttempt(ctx, i)
+
 		if !opts.budget.check(i != 0) {
 			return errors.New("retry budget exhausted")
 		}

--- a/retry_test.go
+++ b/retry_test.go
@@ -97,13 +97,10 @@ func TestAbort(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	var n int
 
 	cb := func(ctx context.Context) error {
-		n++
-
-		err := fmt.Errorf("n = %d", n)
-		if n == 1 {
+		err := fmt.Errorf("n = %d", Attempt(ctx)+1)
+		if Attempt(ctx) == 0 {
 			return err
 		}
 		return Abort(err)


### PR DESCRIPTION
This allows the called function to determine whether this is the first call or a retry. One of the uses is the *Transport* type which adds the `Retry-Attempt` HTTP header to retrying requests.